### PR TITLE
make r-base run-time dependency optional

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - rmodule.patch
 
 build:
-  number: 1
+  number: 2
   script_env:
     - SDKROOT  # [osx]
   rpaths:
@@ -41,11 +41,13 @@ requirements:
     - r-base
 
   run:
-    - r-base
     - coda
     - python
     - numpy
     - cffi
+
+  run_constrained:
+    - r-base
 
 test:
   commands:
@@ -56,6 +58,8 @@ test:
     - "\"%R%\" -e \"library('harp')\""  # [win]
   imports:
     - harp
+  requires:
+    - r-base
 
 about:
   home: https://github.com/stcorp/harp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - flex  # [not win]
     - m2-bison  # [win]
     - m2-flex  # [win]
+    - r-base
 
   host:
     - coda
@@ -38,7 +39,6 @@ requirements:
     - hdf4
     - hdf5
     - jpeg
-    - r-base
 
   run:
     - coda


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
