### PR TITLE
use HDF 1.8 version of H5Oget_info

### DIFF
--- a/recipe/hdf5getinfo.patch
+++ b/recipe/hdf5getinfo.patch
@@ -1,0 +1,20 @@
+diff --git a/config.h.cmake.in b/config.h.cmake.in
+index 690c4eb9..621ba1e6 100644
+--- a/config.h.cmake.in
++++ b/config.h.cmake.in
+@@ -344,9 +344,14 @@ int strncasecmp(const char *, const char *, size_t);
+ int vsnprintf(const char *, size_t, const char *, va_list ap);
+ #endif
+ 
+-/* Make sure we use the 1.6 compatibility API for HDF 1.8 */
++/* Make sure we use the HDF 1.6 compatibility API */
+ #define H5_USE_16_API
+ 
++/* H5Oget_info did not exist in HDF 1.6, so make sure to use 1.8 for this */
++#define H5Oget_info_vers 1
++#define H5Oget_info_by_name_vers 1
++#define H5O_info_t_vers 1
++
+ #ifdef WIN32
+ 
+ /* need to include this before we redefine lseek, etc. */

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,10 @@ source:
     - findjpeg.patch
     - findr.patch
     - rmodule.patch
+    - hdf5getinfo.patch
 
 build:
-  number: 1
+  number: 2
   script_env:
     - SDKROOT  # [osx]
   rpaths:


### PR DESCRIPTION
this doesn't exist in HDF 1.6, and was made incompatible with
HDF 1.12, so we need to specify the HDF 1.8 version.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
