### PR TITLE
avoid numpy.asscalar

### DIFF
--- a/recipe/asscalar.patch
+++ b/recipe/asscalar.patch
@@ -1,0 +1,11 @@
+--- a/python/_harppy.py
++++ b/python/_harppy.py
+@@ -869,7 +869,7 @@ def _import_variable(c_variable):
+ 
+     num_dimensions = c_variable.num_dimensions
+     if num_dimensions == 0:
+-        variable = Variable(numpy.asscalar(data))
++        variable = Variable(data.item())
+     else:
+         data = data.reshape([c_variable.dimension[i] for i in range(num_dimensions)])
+         dimension = [_get_py_dimension_type(c_variable.dimension_type[i]) for i in range(num_dimensions)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,11 @@ package:
 source:
   url: https://github.com/stcorp/harp/releases/download/{{ version }}/harp-{{ version }}.tar.gz
   sha256: e14ed63c9664e62c81f93df40e2b80a2a2e65dfaef36023f5dc3744cf39eaa0a
+  patches:
+    - asscalar.patch
 
 build:
-  number: 0
+  number: 1
   script_env:
     - SDKROOT  # [osx]
   rpaths:


### PR DESCRIPTION
as it was removed with numpy 1.23

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
